### PR TITLE
Remove availability zone from `unhealthy host` alert

### DIFF
--- a/elb-application.tf
+++ b/elb-application.tf
@@ -191,7 +191,7 @@ module "elb_application_monitor_healthy_host_count" {
   timeboard_id   = "${join(",", datadog_timeboard.elb_application.*.id)}"
 
   name               = "${var.product_domain} - ${var.lb_name} - ${var.environment} - Number of Healthy Hosts is Low"
-  query              = "sum(last_1m):sum:aws.applicationelb.healthy_host_count{name:${var.lb_name}, environment:${var.environment}} by {name, availability-zone} <= ${var.healthy_host_count_thresholds["critical"]}"
+  query              = "sum(last_1m):sum:aws.applicationelb.healthy_host_count{name:${var.lb_name}, environment:${var.environment}} by {name} <= ${var.healthy_host_count_thresholds["critical"]}"
   thresholds         = "${var.healthy_host_count_thresholds}"
   evaluation_delay   = "900"
   message            = "${var.healthy_host_count_message}"

--- a/elb-classic.tf
+++ b/elb-classic.tf
@@ -249,7 +249,7 @@ module "elb_classic_monitor_healthy_host_count" {
   timeboard_id   = "${join(",", datadog_timeboard.elb_classic.*.id)}"
 
   name               = "${var.product_domain} - ${var.lb_name} - ${var.environment} - Number of Healthy Hosts is Low"
-  query              = "avg(last_1m):sum:aws.elb.healthy_host_count{name:${var.lb_name}, environment:${var.environment}} by {name, availability-zone} <= ${var.healthy_host_count_thresholds["critical"]}"
+  query              = "avg(last_1m):sum:aws.elb.healthy_host_count{name:${var.lb_name}, environment:${var.environment}} by {name} <= ${var.healthy_host_count_thresholds["critical"]}"
   thresholds         = "${var.healthy_host_count_thresholds}"
   evaluation_delay   = "900"
   message            = "${var.healthy_host_count_message}"


### PR DESCRIPTION
emove availability zone from `unhealthy host` alert since there is possibility there is one host in 2 availability zones and one is being canary released (thus triggering an alert while it's actually expected).